### PR TITLE
Add devnet-7 support

### DIFF
--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -25,9 +25,9 @@ program
       `-n, --${networkOptionName} <network>`,
       'Ethereum network which will be used for request processing'
     )
-      .choices(['holesky', 'sepolia', 'mekong', 'local_devnet'])
+      .choices(['holesky', 'sepolia', 'mekong', 'local_pectra_devnet', 'pectra_devnet_7'])
       .makeOptionMandatory(true)
-      .default('local_devnet')
+      .default('local_pectra_devnet')
   )
   .requiredOption(
     `-r, --${jsonRpcOptionName} <jsonRpcUrl>`,

--- a/src/network-config.ts
+++ b/src/network-config.ts
@@ -10,10 +10,15 @@ export const networkConfig: Record<string, NetworkConfig> = {
     withdrawalContractAddress: '0x09Fc772D0857550724b07B850a4323f39112aAaA',
     chainId: 7078815900n
   },
-  local_devnet: {
+  local_pectra_devnet: {
     consolidationContractAddress: CONSOLIDATION_CONTRACT_ADDRESS,
     withdrawalContractAddress: WITHDRAWAL_CONTRACT_ADDRESS,
     chainId: 3151908n
+  },
+  pectra_devnet_7: {
+    consolidationContractAddress: CONSOLIDATION_CONTRACT_ADDRESS,
+    withdrawalContractAddress: WITHDRAWAL_CONTRACT_ADDRESS,
+    chainId: 7032118028n
   },
   holesky: {
     consolidationContractAddress: CONSOLIDATION_CONTRACT_ADDRESS,


### PR DESCRIPTION
## Summary

This PR adds support for the public devnet-7 testnet which is a temporary replacement for the Holesky testnet due to the ongoing finalization issues.