### PR TITLE
Hotfix: Fix semantic-release workflow

### DIFF
--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -40,7 +40,7 @@ jobs:
           cache: "npm"
 
       - name: "Install dependencies"
-        run: "npm ci"
+        run: "npm ci --ignore-scripts"
 
       - name: "Show current version"
         run: |


### PR DESCRIPTION
## Summary

The postinstall script (bun run scripts/package/patch-native-modules.ts) patches native modules for cross-platform binary builds. The semantic-release workflow uses npm ci, which triggers this script. However, bun isn't installed in that workflow, and the patching is irrelevant for semantic-release (it only bumps versions and creates tags).                                                                                                      
                                                            
Adding `--ignore-scripts` to npm ci skips all lifecycle scripts in the semantic-release workflow. Other workflows (ci.yaml, release.yaml) are unaffected as they use bun install.